### PR TITLE
Ruby 1.9.2, Rails 3 (script/rails server) working...

### DIFF
--- a/additionals/autoload/ruby_debugger.vim
+++ b/additionals/autoload/ruby_debugger.vim
@@ -377,10 +377,10 @@ let g:RubyDebugger.queue = s:Queue.new()
 
 
 " Run debugger server. It takes one optional argument with path to debugged
-" ruby script ('script/server webrick' by default)
+" ruby script ('script/rails server webrick' by default)
 function! RubyDebugger.start(...) dict
   let g:RubyDebugger.server = s:Server.new(s:hostname, s:rdebug_port, s:debugger_port, s:runtime_dir, s:tmp_file, s:server_output_file)
-  let script = a:0 && !empty(a:1) ? a:1 : 'script/server webrick'
+  let script = a:0 && !empty(a:1) ? a:1 : 'script/rails server webrick'
   if script[0] != '/'
     let script = getcwd() . '/' . substitute(script, "'", "", "g")
   endif

--- a/additionals/autoload/ruby_debugger.vim
+++ b/additionals/autoload/ruby_debugger.vim
@@ -10,6 +10,10 @@ let s:runtime_dir = expand('<sfile>:h:h')
 " this plugin
 let s:tmp_file = s:runtime_dir . '/tmp/ruby_debugger'
 let s:server_output_file = s:runtime_dir . '/tmp/ruby_debugger_output'
+" Default id for sign of last line
+let s:last_line = 0
+let s:last_file = ""
+let s:last_line_sign_id = 119
 " Default id for sign of current line
 let s:current_line_sign_id = 120
 let s:separator = "++vim-ruby-debugger separator++"
@@ -24,6 +28,10 @@ endif
 " Init breakpoint signs
 hi def link Breakpoint Error
 sign define breakpoint linehl=Breakpoint  text=xx
+
+" Init last line signs
+hi def link LastLine Normal 
+sign define last_line linehl=LastLine text=..
 
 " Init current line signs
 hi def link CurrentLine DiffAdd 
@@ -214,6 +222,11 @@ endfunction
 
 function! s:unplace_sign_of_current_line()
   if has("signs")
+    if !empty(s:last_file)
+      exe ":sign unplace " . s:last_line_sign_id
+      let s:last_line_sign_id = s:last_line_sign_id == 119 ? 118 : 119
+      exe ":sign place " . s:last_line_sign_id . " line=" . s:last_line . " name=last_line file=" . s:last_file
+    endif
     exe ":sign unplace " . s:current_line_sign_id
   endif
 endfunction
@@ -603,7 +616,10 @@ endfunction
 " Exit
 function! RubyDebugger.exit() dict
   call g:RubyDebugger.queue.add("exit")
-  call s:clear_current_state()
+  if has("signs")
+    exe ":sign unplace " . s:last_line_sign_id
+    exe ":sign unplace " . s:current_line_sign_id
+  endif
   call g:RubyDebugger.queue.execute()
 endfunction
 
@@ -645,6 +661,8 @@ function! RubyDebugger.commands.jump_to_breakpoint(cmd) dict
   call g:RubyDebugger.logger.put("Jumped to breakpoint " . attrs.file . ":" . attrs.line)
 
   if has("signs")
+    let s:last_line = attrs.line
+    let s:last_file = attrs.file
     exe ":sign place " . s:current_line_sign_id . " line=" . attrs.line . " name=current_line file=" . attrs.file
   endif
 endfunction

--- a/additionals/autoload/ruby_debugger.vim
+++ b/additionals/autoload/ruby_debugger.vim
@@ -381,6 +381,9 @@ let g:RubyDebugger.queue = s:Queue.new()
 function! RubyDebugger.start(...) dict
   let g:RubyDebugger.server = s:Server.new(s:hostname, s:rdebug_port, s:debugger_port, s:runtime_dir, s:tmp_file, s:server_output_file)
   let script = a:0 && !empty(a:1) ? a:1 : 'script/server webrick'
+  if script[0] != '/'
+    let script = getcwd() . '/' . substitute(script, "'", "", "g")
+  endif
   echo "Loading debugger..."
   call g:RubyDebugger.server.start(script)
 

--- a/ruby_debugger/before.vim
+++ b/ruby_debugger/before.vim
@@ -10,6 +10,10 @@ let s:runtime_dir = expand('<sfile>:h:h')
 " this plugin
 let s:tmp_file = s:runtime_dir . '/tmp/ruby_debugger'
 let s:server_output_file = s:runtime_dir . '/tmp/ruby_debugger_output'
+" Default id for sign of last line
+let s:last_line = 0
+let s:last_file = ""
+let s:last_line_sign_id = 119
 " Default id for sign of current line
 let s:current_line_sign_id = 120
 let s:separator = "++vim-ruby-debugger separator++"

--- a/ruby_debugger/commands.vim
+++ b/ruby_debugger/commands.vim
@@ -10,6 +10,8 @@ function! RubyDebugger.commands.jump_to_breakpoint(cmd) dict
   call g:RubyDebugger.logger.put("Jumped to breakpoint " . attrs.file . ":" . attrs.line)
 
   if has("signs")
+    let s:last_line = attrs.line
+    let s:last_file = attrs.file
     exe ":sign place " . s:current_line_sign_id . " line=" . attrs.line . " name=current_line file=" . attrs.file
   endif
 endfunction

--- a/ruby_debugger/common.vim
+++ b/ruby_debugger/common.vim
@@ -146,6 +146,11 @@ endfunction
 
 function! s:unplace_sign_of_current_line()
   if has("signs")
+    if !empty(s:last_file)
+      exe ":sign unplace " . s:last_line_sign_id
+      let s:last_line_sign_id = s:last_line_sign_id == 119 ? 118 : 119
+      exe ":sign place " . s:last_line_sign_id . " line=" . s:last_line . " name=last_line file=" . s:last_file
+    endif
     exe ":sign unplace " . s:current_line_sign_id
   endif
 endfunction

--- a/ruby_debugger/init.vim
+++ b/ruby_debugger/init.vim
@@ -13,7 +13,7 @@ noremap <leader>c  :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger
 noremap <leader>e  :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.exit()<CR>
 noremap <leader>d  :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.remove_breakpoints()<CR>
 
-command! -nargs=? -complete=file Rdebugger call ruby_debugger#load_debugger() | call g:RubyDebugger.start(<q-args>) 
+command! -nargs=* -complete=file Rdebugger call ruby_debugger#load_debugger() | call g:RubyDebugger.start(<q-args>)
 command! -nargs=0 RdbStop call g:RubyDebugger.stop() 
 command! -nargs=1 RdbCommand call g:RubyDebugger.send_command_wrapper(<q-args>) 
 command! -nargs=0 RdbTest call g:RubyDebugger.run_test() 

--- a/ruby_debugger/public.vim
+++ b/ruby_debugger/public.vim
@@ -9,6 +9,9 @@ let g:RubyDebugger.queue = s:Queue.new()
 function! RubyDebugger.start(...) dict
   let g:RubyDebugger.server = s:Server.new(s:hostname, s:rdebug_port, s:debugger_port, s:runtime_dir, s:tmp_file, s:server_output_file)
   let script = a:0 && !empty(a:1) ? a:1 : 'script/server webrick'
+  if script[0] != '/'
+    let script = getcwd() . '/' . substitute(script, "'", "", "g")
+  endif
   echo "Loading debugger..."
   call g:RubyDebugger.server.start(script)
 

--- a/ruby_debugger/public.vim
+++ b/ruby_debugger/public.vim
@@ -5,10 +5,10 @@ let g:RubyDebugger.queue = s:Queue.new()
 
 
 " Run debugger server. It takes one optional argument with path to debugged
-" ruby script ('script/server webrick' by default)
+" ruby script ('script/rails server webrick' by default)
 function! RubyDebugger.start(...) dict
   let g:RubyDebugger.server = s:Server.new(s:hostname, s:rdebug_port, s:debugger_port, s:runtime_dir, s:tmp_file, s:server_output_file)
-  let script = a:0 && !empty(a:1) ? a:1 : 'script/server webrick'
+  let script = a:0 && !empty(a:1) ? a:1 : 'script/rails server webrick'
   if script[0] != '/'
     let script = getcwd() . '/' . substitute(script, "'", "", "g")
   endif

--- a/ruby_debugger/public.vim
+++ b/ruby_debugger/public.vim
@@ -231,7 +231,10 @@ endfunction
 " Exit
 function! RubyDebugger.exit() dict
   call g:RubyDebugger.queue.add("exit")
-  call s:clear_current_state()
+  if has("signs")
+    exe ":sign unplace " . s:last_line_sign_id
+    exe ":sign unplace " . s:current_line_sign_id
+  endif
   call g:RubyDebugger.queue.execute()
 endfunction
 

--- a/vim/autoload/ruby_debugger.vim
+++ b/vim/autoload/ruby_debugger.vim
@@ -377,12 +377,13 @@ let g:RubyDebugger.queue = s:Queue.new()
 
 
 " Run debugger server. It takes one optional argument with path to debugged
-" ruby script ('script/server webrick' by default)
+" ruby script ('script/rails server webrick' by default)
 function! RubyDebugger.start(...) dict
   let g:RubyDebugger.server = s:Server.new(s:hostname, s:rdebug_port, s:debugger_port, s:runtime_dir, s:tmp_file, s:server_output_file)
-  let script = a:0 && !empty(a:1) ? a:1 : 'script/server webrick'
+  let script = a:0 && !empty(a:1) ? a:1 : 'script/rails server webrick'
+  let script = substitute(script, "'", "", "g")
   if script[0] != '/'
-    let script = getcwd() . '/' . substitute(script, "'", "", "g")
+    let script = getcwd() . '/' . script
   endif
   echo "Loading debugger..."
   call g:RubyDebugger.server.start(script)

--- a/vim/autoload/ruby_debugger.vim
+++ b/vim/autoload/ruby_debugger.vim
@@ -381,6 +381,9 @@ let g:RubyDebugger.queue = s:Queue.new()
 function! RubyDebugger.start(...) dict
   let g:RubyDebugger.server = s:Server.new(s:hostname, s:rdebug_port, s:debugger_port, s:runtime_dir, s:tmp_file, s:server_output_file)
   let script = a:0 && !empty(a:1) ? a:1 : 'script/server webrick'
+  if script[0] != '/'
+    let script = getcwd() . '/' . substitute(script, "'", "", "g")
+  endif
   echo "Loading debugger..."
   call g:RubyDebugger.server.start(script)
 

--- a/vim/plugin/ruby_debugger.vim
+++ b/vim/plugin/ruby_debugger.vim
@@ -13,7 +13,7 @@ noremap <leader>c  :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger
 noremap <leader>e  :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.exit()<CR>
 noremap <leader>d  :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.remove_breakpoints()<CR>
 
-command! -nargs=? -complete=file Rdebugger call ruby_debugger#load_debugger() | call g:RubyDebugger.start(<q-args>) 
+command! -nargs=* -complete=file Rdebugger call ruby_debugger#load_debugger() | call g:RubyDebugger.start(<q-args>)
 command! -nargs=0 RdbStop call g:RubyDebugger.stop() 
 command! -nargs=1 RdbCommand call g:RubyDebugger.send_command_wrapper(<q-args>) 
 command! -nargs=0 RdbTest call g:RubyDebugger.run_test() 


### PR DESCRIPTION
But maybe you find something useful in these commits.

After a little research I discovered a bug better described here:
http://rubyforge.org/tracker/index.php?func=detail&aid=28100&group_id=8883&atid=34290

The workaound is not needed by Rails 3 because of Bundler. Don't include the ruby-debug gem and is all ok, just include:

To use debugger
group :development do
  gem 'ruby-debug-ide19', :require => 'ruby-debug-ide'
end

My environment:
MacVim 7.3, Ruby 1.9.2
ruby-debug-base19 (0.11.24)
ruby-debug-ide19 (0.4.12)
ruby-debug19 (0.11.6)
