### PR TITLE
Updated how the mappings are done

### DIFF
--- a/plugin/ruby_debugger.vim
+++ b/plugin/ruby_debugger.vim
@@ -1,17 +1,56 @@
+" Set g:ruby_debugger_create_default_mappings to 0 if you wish not to create any
+" key mappings (useful if you wish to do them yourself).
+if !exists('g:ruby_debugger_create_default_mappings')
+    let g:ruby_debugger_create_default_mappings = 1
+endif
+
 if exists("g:ruby_debugger_loaded")
   finish
 endif
 
-noremap <leader>b  :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.toggle_breakpoint()<CR>
-noremap <leader>v  :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.open_variables()<CR>
-noremap <leader>m  :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.open_breakpoints()<CR>
-noremap <leader>t  :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.open_frames()<CR>
-noremap <leader>s  :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.step()<CR>
-noremap <leader>f  :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.finish()<CR>
-noremap <leader>n  :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.next()<CR>
-noremap <leader>c  :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.continue()<CR>
-noremap <leader>e  :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.exit()<CR>
-noremap <leader>d  :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.remove_breakpoints()<CR>
+noremap <plug>ruby_debugger_breakpoint :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.toggle_breakpoint()<cr>
+noremap <plug>ruby_debugger_open_variables :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.open_variables()<CR>
+noremap <plug>ruby_debugger_open_breakpoints :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.open_breakpoints()<CR>
+noremap <plug>ruby_debugger_open_frames :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.open_frames()<CR>
+noremap <plug>ruby_debugger_step :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.step()<CR>
+noremap <plug>ruby_debugger_finish :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.finish()<CR>
+noremap <plug>ruby_debugger_next :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.next()<CR>
+noremap <plug>ruby_debugger_continue :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.continue()<CR>
+noremap <plug>ruby_debugger_exit :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.exit()<CR>
+noremap <plug>ruby_debugger_remove_breakpoints :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.remove_breakpoints()<CR>
+
+if g:ruby_debugger_create_default_mappings
+    if (!hasmapto('<leader>b'))
+        nmap <leader>b <plug>ruby_debugger_breakpoint
+    endif
+    if (!hasmapto('<leader>v'))
+        nmap <leader>v <plug>ruby_debugger_open_variables
+    endif
+    if (!hasmapto('<leader>m'))
+        nmap <leader>m <plug>ruby_debugger_open_breakpoints
+    endif
+    if (!hasmapto('<leader>t'))
+        nmap <leader>t <plug>ruby_debugger_open_frames
+    endif
+    if (!hasmapto('<leader>s'))
+        nmap <leader>s <plug>ruby_debugger_step
+    endif
+    if (!hasmapto('<leader>f'))
+        nmap <leader>f <plug>ruby_debugger_finish
+    endif
+    if (!hasmapto('<leader>n'))
+        nmap <leader>n <plug>ruby_debugger_next
+    endif
+    if (!hasmapto('<leader>c'))
+        nmap <leader>c <plug>ruby_debugger_continue
+    endif
+    if (!hasmapto('<leader>e'))
+        nmap <leader>e <plug>ruby_debugger_exit
+    endif
+    if (!hasmapto('<leader>d'))
+        nmap <leader>d <plug>ruby_debugger_remove_breakpoints
+    endif
+endif
 
 command! -nargs=* -complete=file Rdebugger call ruby_debugger#load_debugger() | call g:RubyDebugger.start(<q-args>) 
 command! -nargs=0 RdbStop call g:RubyDebugger.stop() 


### PR DESCRIPTION
Hey,

 I've created a patch to update how the mappings are done so you can override them with ease, for example you can now do things like

``` vim
let g:ruby_debugger_create_default_mappings = 0

" Setup mappings for ruby-debugger.
nmap <leader>db <plug>ruby_debugger_breakpoint
nmap <leader>dv <plug>ruby_debugger_open_variables
nmap <leader>dm <plug>ruby_debugger_open_breakpoints
nmap <leader>dt <plug>ruby_debugger_open_frames
nmap <leader>ds <plug>ruby_debugger_step
nmap <leader>df <plug>ruby_debugger_finish
nmap <leader>dn <plug>ruby_debugger_next
nmap <leader>dc <plug>ruby_debugger_continue
nmap <leader>de <plug>ruby_debugger_exit
nmap <leader>dd <plug>ruby_debugger_remove_breakpoints
```

(I like to prefix all the commands with d)

It will now also make sure the mapping isn't already in use, I had a lot of conflicts with NERD Tree and Command-T.
