### PR TITLE
Add ruby_debugger#statusline

### DIFF
--- a/autoload/ruby_debugger.vim
+++ b/autoload/ruby_debugger.vim
@@ -36,6 +36,13 @@ fun! ruby_debugger#load_debugger()
   endif
 endf
 
+fun! ruby_debugger#statusline()
+  let is_running = g:RubyDebugger.is_running()
+  if is_running == 0
+    return ''
+  endif
+  return '[ruby debugger running]'
+endfunction
 
 " Check all requirements for the current plugin
 fun! s:check_prerequisites()
@@ -455,6 +462,12 @@ function! RubyDebugger.stop() dict
   endif
 endfunction
 
+function! RubyDebugger.is_running()
+  if has_key(g:RubyDebugger, 'server')
+    return g:RubyDebugger.server.is_running()
+  endif
+  return 0
+endfunction
 
 " This function receives commands from the debugger. When ruby_debugger.rb
 " gets output from rdebug-ide, it writes it to the special file and 'kick'

--- a/doc/ruby_debugger.txt
+++ b/doc/ruby_debugger.txt
@@ -101,6 +101,13 @@ It will kill any listeners of ports 39767 and 39768 and run rdebug-ide and
    * <Leader>c - continue
    * <Leader>d - remove all breakpoints
 
+6. To see when the ruby debugger is running, you can add the following function call
+to your status line:
+
+   set statusline=%{ruby_debugger#statusline()}
+
+   When the debugger is running you'll see '[ruby debugger running]'
+
 ==============================================================================
 DETAILS					*ruby-debugger-details*
 

--- a/src/ruby_debugger/before.vim
+++ b/src/ruby_debugger/before.vim
@@ -36,6 +36,13 @@ fun! ruby_debugger#load_debugger()
   endif
 endf
 
+fun! ruby_debugger#statusline()
+  let is_running = g:RubyDebugger.is_running()
+  if is_running == 0
+    return ''
+  endif
+  return '[ruby debugger running]'
+endfunction
 
 " Check all requirements for the current plugin
 fun! s:check_prerequisites()

--- a/src/ruby_debugger/public.vim
+++ b/src/ruby_debugger/public.vim
@@ -30,6 +30,12 @@ function! RubyDebugger.stop() dict
   endif
 endfunction
 
+function! RubyDebugger.is_running()
+  if has_key(g:RubyDebugger, 'server')
+    return g:RubyDebugger.server.is_running()
+  endif
+  return 0
+endfunction
 
 " This function receives commands from the debugger. When ruby_debugger.rb
 " gets output from rdebug-ide, it writes it to the special file and 'kick'


### PR DESCRIPTION
This adds a function for use in the vim statusline.

If the ruby debugger is active the status line will indicate so, otherwise nothing is displayed.
