### PR TITLE
add RdbTestSingle command option that will pass line to rspec command

### DIFF
--- a/autoload/ruby_debugger.vim
+++ b/autoload/ruby_debugger.vim
@@ -692,10 +692,11 @@ endfunction
 
 
 " Debug current opened test
-function! RubyDebugger.run_test() dict
+function! RubyDebugger.run_test(...) dict
   let file = s:get_filename()
   if file =~ '_spec\.rb$'
-    call g:RubyDebugger.start(g:ruby_debugger_spec_path . ' ' . file)
+    let line = a:0 && a:0 > 0 && !empty(a:1) ? a:1 : " "
+    call g:RubyDebugger.start(g:ruby_debugger_spec_path . ' ' . file . line)
   elseif file =~ '\.feature$'
     call g:RubyDebugger.start(g:ruby_debugger_cucumber_path . ' ' . file)
   elseif file =~ '_test\.rb$'

--- a/doc/ruby_debugger.txt
+++ b/doc/ruby_debugger.txt
@@ -233,6 +233,10 @@ For this, set some variables in your .vimrc. E.g.: >
   let g:ruby_debugger_spec_path = 'c:\gembins\spec'         " set Rspec path
   let g:ruby_debugger_cucumber_path = 'c:\gembins\cucumber' " set Cucumber path
 
+A single rspec test can be invoked by RdbTestSingle which will invoke rspec
+and pass the current line to rspec via "-l" argument to rspec.  For Cucumber
+and Test::Unit all tests/features are run.
+
 ==============================================================================
 RUBY 1.9 AND RAILS 3				*ruby-debugger-ruby19*
 

--- a/plugin/ruby_debugger.vim
+++ b/plugin/ruby_debugger.vim
@@ -19,6 +19,7 @@ command! -nargs=* -complete=file Rdebugger call ruby_debugger#load_debugger() | 
 command! -nargs=0 RdbStop call g:RubyDebugger.stop() 
 command! -nargs=1 RdbCommand call g:RubyDebugger.send_command_wrapper(<q-args>) 
 command! -nargs=0 RdbTest call g:RubyDebugger.run_test() 
+command! -nargs=0 RdbTestSingle call g:RubyDebugger.run_test(" -l " . line("."))
 command! -nargs=1 RdbEval call g:RubyDebugger.eval(<q-args>)
 command! -nargs=1 RdbCond call g:RubyDebugger.conditional_breakpoint(<q-args>)
 command! -nargs=1 RdbCatch call g:RubyDebugger.catch_exception(<q-args>)

--- a/src/ruby_debugger/init.vim
+++ b/src/ruby_debugger/init.vim
@@ -19,6 +19,7 @@ command! -nargs=* -complete=file Rdebugger call ruby_debugger#load_debugger() | 
 command! -nargs=0 RdbStop call g:RubyDebugger.stop() 
 command! -nargs=1 RdbCommand call g:RubyDebugger.send_command_wrapper(<q-args>) 
 command! -nargs=0 RdbTest call g:RubyDebugger.run_test() 
+command! -nargs=0 RdbTestSingle call g:RubyDebugger.run_test(" -l " . line("."))
 command! -nargs=1 RdbEval call g:RubyDebugger.eval(<q-args>)
 command! -nargs=1 RdbCond call g:RubyDebugger.conditional_breakpoint(<q-args>)
 command! -nargs=1 RdbCatch call g:RubyDebugger.catch_exception(<q-args>)

--- a/src/ruby_debugger/public.vim
+++ b/src/ruby_debugger/public.vim
@@ -260,10 +260,11 @@ endfunction
 
 
 " Debug current opened test
-function! RubyDebugger.run_test() dict
+function! RubyDebugger.run_test(...) dict
   let file = s:get_filename()
   if file =~ '_spec\.rb$'
-    call g:RubyDebugger.start(g:ruby_debugger_spec_path . ' ' . file)
+    let line = a:0 && a:0 > 0 && !empty(a:1) ? a:1 : " "
+    call g:RubyDebugger.start(g:ruby_debugger_spec_path . ' ' . file . line)
   elseif file =~ '\.feature$'
     call g:RubyDebugger.start(g:ruby_debugger_cucumber_path . ' ' . file)
   elseif file =~ '_test\.rb$'


### PR DESCRIPTION
This commit adds a command RdbTestSingle that passes -l with the current line to rspec when invoked.
